### PR TITLE
Ruby 2.3 fixes

### DIFF
--- a/lib/closed_struct.rb
+++ b/lib/closed_struct.rb
@@ -2,13 +2,13 @@ require 'ostruct'
 
 # Like OpenStruct, but raises an exception if you try to access a member that wasn't specified in the initializer.
 class ClosedStruct < OpenStruct
-  
+
   def self.r_new(hash)
     closed_struct = ClosedStruct.new(hash)
     closed_struct.send(:recursive_initialize)
     closed_struct
   end
-  
+
   def initialize(*args)
     if args.length == 1 and args.first.kind_of?(Hash)
       super(args.first)
@@ -20,7 +20,7 @@ class ClosedStruct < OpenStruct
     end
     @closed = true
   end
-  
+
   def new_ostruct_member(name)
     if @closed
       raise RuntimeError, "cannot add members to closed struct"
@@ -28,11 +28,7 @@ class ClosedStruct < OpenStruct
       super
     end
   end
-  
-  def method_missing(name, *args)
-    raise NoMethodError, "undefined method '#{name}' for #{self}"
-  end
-  
+
   def id
     if @table.has_key?(:id)
       @table[:id]
@@ -40,13 +36,13 @@ class ClosedStruct < OpenStruct
       method_missing(:id)
     end
   end
-  
+
   def to_h
     @table.dup
   end
-  
+
 private
-  
+
   def recursive_initialize
     @table.each do |k, v|
       if v.kind_of?(Hash)
@@ -56,5 +52,5 @@ private
       end
     end
   end
-  
+
 end

--- a/lib/closed_struct.rb
+++ b/lib/closed_struct.rb
@@ -20,14 +20,6 @@ class ClosedStruct < OpenStruct
     end
   end
 
-  def new_ostruct_member(name)
-    if @closed
-      raise RuntimeError, "cannot add members to closed struct"
-    else
-      super
-    end
-  end
-
   def id
     if @table.has_key?(:id)
       @table[:id]

--- a/lib/closed_struct.rb
+++ b/lib/closed_struct.rb
@@ -18,7 +18,6 @@ class ClosedStruct < OpenStruct
     else
       raise ArgumentError, "invalid arguments: #{args.inspect}"
     end
-    @closed = true
   end
 
   def new_ostruct_member(name)


### PR DESCRIPTION
In ruby 2.3.0 openstruct has been update. 
They removed calling in `new_ostruct_member` in initializer.
Also update `method_missing` method
